### PR TITLE
Using POSIX timer instead of timerfd for old version kernel/libc such as Debian/lenny

### DIFF
--- a/configure.in
+++ b/configure.in
@@ -68,6 +68,8 @@ linux*)
 	if test "$enable_timerfd" = "no"; then
 		CXXFLAGS="$CXXFLAGS -DDISABLE_TIMERFD"
 		CFLAGS="$CFLAGS -DDISABLE_TIMERFD"
+		AC_CHECK_LIB(rt,timer_create,,
+			AC_MSG_ERROR([Can't find rt library]))
 	else
 		AC_CHECK_HEADER(sys/timerfd.h, [],
 						AC_MSG_ERROR([sys/timerfd.h is not available.

--- a/mpsrc/wavy_timer.cc
+++ b/mpsrc/wavy_timer.cc
@@ -15,7 +15,6 @@
 //    See the License for the specific language governing permissions and
 //    limitations under the License.
 //
-#ifndef DISABLE_TIMERFD
 #include "wavy_timer.h"
 
 namespace mp {
@@ -75,5 +74,4 @@ void loop::remove_timer(int ident)
 
 }  // namespace wavy
 }  // namespace mp
-#endif
 

--- a/mpsrc/wavy_timer.h
+++ b/mpsrc/wavy_timer.h
@@ -15,7 +15,6 @@
 //    See the License for the specific language governing permissions and
 //    limitations under the License.
 //
-#ifndef DISABLE_TIMERFD
 #ifndef WAVY_TIMER_H__
 #define WAVY_TIMER_H__
 
@@ -86,5 +85,4 @@ private:
 }  // namespace mp
 
 #endif /* wavy_timer.h */
-#endif
 


### PR DESCRIPTION
debian/lennyでmessagepack-rpc for c++を使いたいのですが、
libcのバージョンが古く、timerfdが使えないため、代替として、
--disable-timerfdを指定したらtimerfdの代わりにPOSIX timerを使う実装を追加してみました。
もし宜しければマージしてください。
# 実はsignalfdも同様の理由で使えないので、本当はそちらも代替実装をしたいのですが、

現在のmsgpack-rpc for c++では、mpioのsignal機能は使っていないみたいなので、そちらは手をつけていません。
