### PR TITLE
Fix Ruby 1.9 module loading

### DIFF
--- a/preprocess
+++ b/preprocess
@@ -10,7 +10,7 @@ function r() {
 function preprocess() {
 	file="$1"
 	out="$(dirname "$file")/$(basename "$file" mpl)"
-	r "$RUBY" mplex -rmpl "$file" -o "$out"
+	r "$RUBY" mplex -r"./mpl" "$file" -o "$out"
 	if [ "$?" != 0 ]; then
 		echo ""
 		echo "** preprocess failed **"


### PR DESCRIPTION
Ruby 1.9 removed the current directory from the load path, so we need to
do absolute path loading inside the _preprocess_ script.
