### PR TITLE
Fixed the booststap preprocess script to use a realtive path to mpl.rb

### DIFF
--- a/preprocess
+++ b/preprocess
@@ -10,7 +10,7 @@ function r() {
 function preprocess() {
 	file="$1"
 	out="$(dirname "$file")/$(basename "$file" mpl)"
-	r "$RUBY" mplex -rmpl "$file" -o "$out"
+	r "$RUBY" mplex -r./mpl "$file" -o "$out"
 	if [ "$?" != 0 ]; then
 		echo ""
 		echo "** preprocess failed **"


### PR DESCRIPTION
When trying to booststrap on stock ubuntu I ran into the following error:

```
$ ./bootstrap
ruby mplex -rmpl mp/object_callback.hmpl -o mp/object_callback.h
/usr/lib/ruby/1.9.1/rubygems/custom_require.rb:36:in `require': cannot load such file -- mpl (LoadError)
    from /usr/lib/ruby/1.9.1/rubygems/custom_require.rb:36:in `require'
    from mplex:173:in `block in <main>'
    from mplex:173:in `each'
    from mplex:173:in `<main>'

    ** preprocess failed **
```

This was caused by the lack of specifying a relative path to the mpl.rb file.
