### PR TITLE
Fixed code typos that prevent compiling on OS X

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,11 @@ Configure and install in the usual way:
     $ make
     $ sudo make install
 
+For OS X, possibly replace `make` by:
+
+    $ make CPPFLAGS='-DMP_FUNCTIONAL_BOOST -DMP_MEMORY_BOOST -I/usr/local/include'
+
+
 
 ## Libraries
 

--- a/mp/memory.h
+++ b/mp/memory.h
@@ -22,7 +22,7 @@
 #include <boost/tr1/memory>
 namespace mp {
 	using std::tr1::shared_ptr;
-	using std::tr1::wak_ptr;
+	using std::tr1::weak_ptr;
 	//using std::tr2::scoped_ptr;
 	using std::tr1::static_pointer_cast;
 	using std::tr1::dynamic_pointer_cast;

--- a/mp/memory.h
+++ b/mp/memory.h
@@ -19,7 +19,7 @@
 #define MP_MEMORY_H__
 
 #ifdef MP_MEMORY_BOOST
-#include <boost/tr1/memory>
+#include <boost/tr1/memory.hpp>
 namespace mp {
 	using std::tr1::shared_ptr;
 	using std::tr1::weak_ptr;

--- a/mpsrc/wavy_kernel.h
+++ b/mpsrc/wavy_kernel.h
@@ -41,7 +41,7 @@
 #endif
 
 #define MP_WAVY_KERNEL_HEADER(sys) \
-	MP_PP_HEADER(., wavy_kernel_, sys, )
+	MP_PP_HEADER(.,wavy_kernel_, sys, )
 
 #ifndef MP_WAVY_KERNEL_BACKLOG_SIZE
 #define MP_WAVY_KERNEL_BACKLOG_SIZE 1024

--- a/preprocess
+++ b/preprocess
@@ -10,7 +10,7 @@ function r() {
 function preprocess() {
 	file="$1"
 	out="$(dirname "$file")/$(basename "$file" mpl)"
-	r "$RUBY" mplex -rmpl "$file" -o "$out"
+	r "$RUBY" mplex -r./mpl "$file" -o "$out"
 	if [ "$?" != 0 ]; then
 		echo ""
 		echo "** preprocess failed **"


### PR DESCRIPTION
After fixing these two typos (and adding the other fix for Ruby's include), I was finally able to compile on OS X.
